### PR TITLE
Add GitHub Actions CI Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI for Portfolio
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run basic HTML lint (optional)
+        run: echo "Pretend we're running lint or build step"


### PR DESCRIPTION
This PR adds a basic GitHub Actions workflow (ci.yml) to run on pull requests to the main branch. It sets up a job named "build" that will be used for future CI checks.
